### PR TITLE
Change `AllUsers` to be consistent with `perMachine`

### DIFF
--- a/Src/Program.cs
+++ b/Src/Program.cs
@@ -186,12 +186,12 @@ namespace VsixUtil
                 UninstallSilent(identifier);
 
                 var perMachine = false;
-                if(installableExtension.Header.AllUsers != perMachine)
+                if (installableExtension.Header.AllUsers != perMachine)
                 {
                     Console.Write(string.Format("Changing `AllUsers` to {0} ... ", perMachine));
                     SetAllUsers(installableExtension, perMachine);
                 }
-                SetAllUsers(installableExtension, perMachine);
+
                 _extensionManager.Install(installableExtension, perMachine);
 
                 var installedExtension = _extensionManager.GetInstalledExtension(identifier);

--- a/Src/Program.cs
+++ b/Src/Program.cs
@@ -184,7 +184,15 @@ namespace VsixUtil
                 var installableExtension = _extensionManager.CreateInstallableExtension(extensionPath);
                 var identifier = installableExtension.Header.Identifier;
                 UninstallSilent(identifier);
-                _extensionManager.Install(installableExtension, perMachine: false);
+
+                var perMachine = false;
+                if(installableExtension.Header.AllUsers != perMachine)
+                {
+                    Console.Write(string.Format("Changing `AllUsers` to {0} ... ", perMachine));
+                    SetAllUsers(installableExtension, perMachine);
+                }
+                SetAllUsers(installableExtension, perMachine);
+                _extensionManager.Install(installableExtension, perMachine);
 
                 var installedExtension = _extensionManager.GetInstalledExtension(identifier);
                 _extensionManager.Enable(installedExtension);
@@ -194,6 +202,14 @@ namespace VsixUtil
             {
                 Console.WriteLine("ERROR: {0}", ex.Message);
             }
+        }
+
+        private static void SetAllUsers(IInstallableExtension extension, bool allUsers)
+        {
+            var header = extension.Header;
+            var flags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
+            var allUsersProperty = header.GetType().GetProperty(nameof(header.AllUsers), flags);
+            allUsersProperty.SetValue(header, allUsers, null);
         }
 
         private void RunUninstall(string identifier)

--- a/Src/Program.cs
+++ b/Src/Program.cs
@@ -208,7 +208,7 @@ namespace VsixUtil
         {
             var header = extension.Header;
             var flags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
-            var allUsersProperty = header.GetType().GetProperty(nameof(header.AllUsers), flags);
+            var allUsersProperty = header.GetType().GetProperty("AllUsers", flags);
             allUsersProperty.SetValue(header, allUsers, null);
         }
 


### PR DESCRIPTION
Hi Jared,

I've been working on the GitHub Extension for Visual Studio. Because it's packaged with Visual Studio 2017, we need to set the `AllUsers` property in the VSIX to `True` (there is no user context when Visual Studio is installing).

Unfortunately this wrecks all kinds of havoc when trying to install a standalone VSIX file. Visual Studio seems to think it owns the extension and will happily and silently replace the contents of the VSIX with the previously installed version! If `AllUsers` is changed to `False`, suddenly everything seems to work fine (no more install/uninstall issues). See here: https://github.com/github/VisualStudio/issues/864

Because I don't necessarily want to deal with two separate VSIX flavors, I've tweaked VsixUtil to ensure that the `AllUsers` property is consistent with `perMachine`. `AllUsers` seems to be a flag that can force that can force `perMachine` to be False. See here:

![image](https://cloud.githubusercontent.com/assets/11719160/23071139/49e0cde6-f525-11e6-8617-42a8b96f9432.png)

When a package has `AllUsers` set to `True`, it will warn that this setting is being changed and continues on with a non-admin install.

Is this something you would be up for incorporating? 😄 

I'll follow up with a PR for basic VS 2017 support...