### PR TITLE
Make the default action install

### DIFF
--- a/Src/Program.cs
+++ b/Src/Program.cs
@@ -136,8 +136,8 @@ namespace VsixUtil
 
         internal static void PrintHelp()
         {
-            Console.WriteLine("vsixutil [/rootSuffix name] [/sku name] /install extensionPath");
-            Console.WriteLine("vsixutil [/rootSuffix name] [/sku name] /uninstall identifier");
+            Console.WriteLine("vsixutil [/install] extensionPath [/rootSuffix name] [/sku name]");
+            Console.WriteLine("vsixutil /uninstall identifier [/rootSuffix name] [/sku name]");
             Console.WriteLine("vsixutil /list [filter]");
         }
     }
@@ -470,8 +470,17 @@ namespace VsixUtil
                         index = args.Length;
                         break;
                     default:
-                        Console.WriteLine("{0} is not a valid argument", args[index]);
-                        return CommandLine.Help;
+                        arg = args[index];
+                        if (!File.Exists(arg))
+                        {
+                            Console.WriteLine("{0} is not a valid argument", arg);
+                            return CommandLine.Help;
+                        }
+
+                        // Default to Install if `arg` file exists.
+                        toolAction = ToolAction.Install;
+                        index += 1;
+                        break;
                 }
             }
 


### PR DESCRIPTION
Sorry to bombard you with pull requests...  😉 

I've tweaked the command line options so that the default action is to (re)install the target file. This means you can associate VSIX files with `vsixutil.exe` and it will generally do the right thing. So much more convenient than using `vsixinstaller.exe`!