### PR TITLE
Resolve issue when installing for multiple instances of VS 2017

### DIFF
--- a/Src/CommandLine.cs
+++ b/Src/CommandLine.cs
@@ -8,15 +8,17 @@
         public readonly VsVersion? VsVersion;
         public readonly string Product;
         public readonly string RootSuffix;
+        public readonly bool DefaultDomain;
         public readonly string Arg;
 
         public CommandLine(ToolAction toolAction = ToolAction.Help, VsVersion? vsVersion = null, string product = null,
-            string rootSuffix = null, string arg = null)
+            string rootSuffix = null, string arg = null, bool defaultDomain = false)
         {
             ToolAction = toolAction;
             VsVersion = vsVersion;
             Product = product;
             RootSuffix = rootSuffix;
+            DefaultDomain = defaultDomain;
             Arg = arg;
         }
     }

--- a/Src/CommandRunner.cs
+++ b/Src/CommandRunner.cs
@@ -99,13 +99,16 @@ namespace VsixUtil
             try
             {
                 Console.Write("{0} Uninstall ... ", _installedVersion);
-                var installedExtension = _extensionManager.GetInstalledExtension(identifier);
-                if (installedExtension != null)
+                IInstalledExtension installedExtension;
+                if (_extensionManager.TryGetInstalledExtension(identifier, out installedExtension))
                 {
                     _extensionManager.Uninstall(installedExtension);
+                    Console.WriteLine("Succeeded");
                 }
-
-                Console.WriteLine("Succeeded");
+                else
+                {
+                    Console.WriteLine("Not Installed");
+                }
             }
             catch (Exception ex)
             {
@@ -117,8 +120,8 @@ namespace VsixUtil
         {
             try
             {
-                var installedExtension = _extensionManager.GetInstalledExtension(identifier);
-                if (installedExtension != null)
+                IInstalledExtension installedExtension;
+                if (_extensionManager.TryGetInstalledExtension(identifier, out installedExtension))
                 {
                     _extensionManager.Uninstall(installedExtension);
                 }

--- a/Src/Program.cs
+++ b/Src/Program.cs
@@ -156,7 +156,30 @@ namespace VsixUtil
 
         static bool FilterProduct(InstalledVersion installedVersion, string product)
         {
-            return product == null || (installedVersion.Product?.StartsWith(product, StringComparison.OrdinalIgnoreCase) ?? false);
+            if (product == null)
+            {
+                return true;
+            }
+
+            var installedProduct = installedVersion.Product;
+            if (installedProduct != null)
+            {
+                if (installedProduct.StartsWith(product, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            var installedApplicationPath = installedVersion.ApplicationPath;
+            if (installedApplicationPath != null)
+            {
+                if (installedApplicationPath.IndexOf(product, StringComparison.OrdinalIgnoreCase) != -1)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         internal static void PrintHelp(IConsoleContext consoleContext)
@@ -167,7 +190,7 @@ namespace VsixUtil
             consoleContext.WriteLine("");
             consoleContext.WriteLine("The following filters can be used with all commands:");
             consoleContext.WriteLine("   /version 15 | 2017");
-            consoleContext.WriteLine("   /product com | Community");
+            consoleContext.WriteLine("   /product com | Community | preview");
         }
     }
 }

--- a/Src/Program.cs
+++ b/Src/Program.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Linq;
+using System.Reflection;
+using System.Diagnostics;
 
 namespace VsixUtil
 {
@@ -16,6 +18,7 @@ namespace VsixUtil
             VsVersion? version = null;
             string product = null;
             var rootSuffix = "";
+            var defaultDomain = false;
             var arg = "";
 
             int index = 0;
@@ -80,6 +83,10 @@ namespace VsixUtil
                         rootSuffix = args[index + 1];
                         index += 2;
                         break;
+                    case "/defaultdomain":
+                        defaultDomain = true;
+                        index++;
+                        break;
                     case "/l":
                     case "/list":
                         toolAction = ToolAction.List;
@@ -109,7 +116,7 @@ namespace VsixUtil
                 }
             }
 
-            return new CommandLine(toolAction, version, product, rootSuffix, arg);
+            return new CommandLine(toolAction, version, product, rootSuffix, arg, defaultDomain: defaultDomain);
         }
 
         internal static void Main(string[] args)
@@ -126,13 +133,13 @@ namespace VsixUtil
             var installedVersions = InstalledVersionUtilities.GetInstalledVersions().Where(iv => Filter(iv, commandLine));
             foreach (var installedVersion in installedVersions)
             {
-                var createDomain = true;
-
-                // HACK: Don't create an app domain when installing for VS 2017.
+                // HACK: We mustn't create an app domain when installing for VS2017.
                 // https://github.com/jaredpar/VsixUtil/pull/8
-                if (commandLine.ToolAction == ToolAction.Install && installedVersion.VsVersion == VsVersion.Vs2017)
+                var createDomain = !commandLine.DefaultDomain;
+                if (createDomain && installedVersion.VsVersion == VsVersion.Vs2017)
                 {
-                    createDomain = false;
+                    ExecuteOutOfProc(consoleContext, installedVersion.ApplicationPath, commandLine.ToolAction, commandLine.Arg);
+                    continue;
                 }
 
                 using (var applicationContext = new ApplicationContext(installedVersion, createDomain))
@@ -142,6 +149,17 @@ namespace VsixUtil
                     commandRunner.Run(commandLine.ToolAction, commandLine.Arg);
                 }
             }
+        }
+
+        private static void ExecuteOutOfProc(ConsoleContext consoleContext, string applicationPath, ToolAction toolAction, string arg)
+        {
+            var exeFile = Assembly.GetEntryAssembly().Location;
+            var arguments = "/defaultDomain /product \"" + applicationPath + "\" /" + toolAction + " \"" + arg + "\"";
+            var startInfo = new ProcessStartInfo(exeFile, arguments) { RedirectStandardOutput = true, CreateNoWindow = true, UseShellExecute = false };
+            var process = Process.Start(startInfo);
+            var output = process.StandardOutput.ReadToEnd();
+            consoleContext.Write(output);
+            process.WaitForExit();
         }
 
         public static bool Filter(InstalledVersion installedVersion, CommandLine commandLine)

--- a/Test/VsixUtil.Tests/ProgramTests.cs
+++ b/Test/VsixUtil.Tests/ProgramTests.cs
@@ -116,14 +116,21 @@ namespace VsixUtil.Tests
                     Assert.That(include, Is.EqualTo(expect));
                 }
 
-                [TestCase("Community", null, true)]
-                [TestCase("Community", "Community", true)]
-                [TestCase("Community", "community", true)]
-                [TestCase("Community", "com", true)]
-                [TestCase("Community", "Enterprise", false)]
-                public void FilterProduct(string product, string filterProduct, bool expect)
+                const string PreviewCommunityPath = @"C:\Program Files(x86)\Microsoft Visual Studio\Preview\Community\Common7\IDE\devenv.exe";
+
+                [TestCase(null, "Community", null, true)]
+                [TestCase(null, "Community", "Community", true)]
+                [TestCase(null, "Community", "community", true)]
+                [TestCase(null, "Community", "com", true)]
+                [TestCase(null, "Community", "Enterprise", false)]
+                [TestCase(PreviewCommunityPath, "Community", PreviewCommunityPath, true)]
+                [TestCase(PreviewCommunityPath, "Community", "Preview", true)]
+                [TestCase(PreviewCommunityPath, "Community", "prev", true)]
+                [TestCase(PreviewCommunityPath, "Community", "devenv", true)]
+                [TestCase(PreviewCommunityPath, "Community", "UNKNOWN", false)]
+                public void FilterProduct(string applicationPath, string product, string filterProduct, bool expect)
                 {
-                    var installedVersion = new InstalledVersion(null, VsVersion.Vs2010, product);
+                    var installedVersion = new InstalledVersion(applicationPath, VsVersion.Vs2010, product);
                     var commandLine = new CommandLine(product: filterProduct);
 
                     var include = Program.Filter(installedVersion, commandLine);


### PR DESCRIPTION
There was an issue when running actions on multiple instances of VS 2017 at once. Everything appeared to work, but it looks like extensions were being cached between the different instances.

This PR executes actions for VS 2017 in the default app domain of a new process. This ensures that assemblies are loaded with the correct codebase.

I've also stopped it throwing an exception when uninstalling and instead reporting either `Succeeded` or `Not Installed` for each instance. This cleans it up and helped with debugging.

Fixes #9 