### PR TITLE
Add support for VS2017 15.5.1

### DIFF
--- a/Src/ExtensionManagerFactory.cs
+++ b/Src/ExtensionManagerFactory.cs
@@ -71,7 +71,7 @@ namespace VsixUtil
             var extensionManagerServiceType = GetExtensionManagerServiceType(installedVersion.VsVersion);
             var extensionManager = (IVsExtensionManager)extensionManagerServiceType
                 .GetConstructors()
-                .Where(x => x.GetParameters().Length == 1 && x.GetParameters()[0].ParameterType.Name.Contains("SettingsManager"))
+                .Where(x => x.GetParameters().Length == 1 && x.GetParameters()[0].ParameterType.IsAssignableFrom(settingsManager.GetType()))
                 .FirstOrDefault()
                 .Invoke(new[] { settingsManager });
             return extensionManager;


### PR DESCRIPTION
```
ExtensionManagerService(ISettingsManager) <--- added in 15.7.3 (or a bit earlier)
ExtensionManagerService(SettingsManager)
```
This means `Where(... ParameterType.Name.Contains("SettingsManager"))` was no longer giving us the right constructor.

Fixes #11.